### PR TITLE
change target to export_target for drush >=7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Exports a specified datastream from all objects given a fielded Solr query.
 
 Examples:
  drush -u 1 islandora_datastream_export  Exporting datastream from object.
- --target=/tmp --query=PID:\"islandora:9\" --dsid=DC
+ --export_target=/tmp --query=PID:\"islandora:9\" --dsid=DC
 
 Options:
  --dsid                                    The datastream id of to be exported datastream. Required.
  --query                                   The Solr query to be ran. Required.
- --target                                  The directory to export the datastreams to. Required.
+ --export_target                                  The directory to export the datastreams to. Required.
   ```
 
 It's to be noted that when specifying a value that some values will need to be

--- a/islandora_datastream_exporter.drush.inc
+++ b/islandora_datastream_exporter.drush.inc
@@ -25,13 +25,13 @@ function islandora_datastream_exporter_drush_command() {
         'description' => dt('The datastream id of to be exported datastream.'),
         'required' => TRUE,
       ),
-      'target' => array(
+      'export_target' => array(
         'description' => dt('The directory to export the datastreams to.'),
         'required' => TRUE,
       ),
     ),
     'examples' => array(
-      'drush -u 1 islandora_datastream_export --target=/tmp --query=PID:\"islandora:9\" --dsid=DC' => dt('Exporting datastream from object.'),
+      'drush -u 1 islandora_datastream_export --export_target=/tmp --query=PID:\"islandora:9\" --dsid=DC' => dt('Exporting datastream from object.'),
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
@@ -42,7 +42,7 @@ function islandora_datastream_exporter_drush_command() {
  * Batch process validation handler.
  */
 function drush_islandora_datastream_exporter_islandora_datastream_export_validate() {
-  $directory = drush_get_option('target');
+  $directory = drush_get_option('export_target');
   if (!is_writable($directory)) {
     return drush_set_error('This is not is a directory', dt('The specified target directory, !dir, is not valid.', array('!dir' => $directory)));
   }
@@ -78,7 +78,7 @@ function islandora_datastream_export_create_batch() {
         array(
           drush_get_option('query'),
           drush_get_option('dsid'),
-          drush_get_option('target'),
+          drush_get_option('export_target'),
         ),
       ),
     ),
@@ -98,7 +98,7 @@ function islandora_datastream_export_create_batch() {
  * @param string $dsid
  *   The datastream ID of the object to be exported.
  * @param string $target
- *   The target directory to export the files to.
+ *   The export_target directory to export the files to.
  * @param array $context
  *   The context of the Drupal batch.
  */


### PR DESCRIPTION
**JIRA Ticket**: (link)

   no jira, just an issue on github repo

# What does this Pull Request do?

 replaces the target parameter with export_target to allow use with drush >7.x  similar to the change to islandora_batch and islandora_book_batch. 

# What's new?

  changes --target to --export_target in drush script and also in Readme.md

# How should this be tested?

  This change should work with existing drush and newer ones, existing will have to use the new parameter.
  Test it on current vagrant (that has 6.x) and then install a newer drush and test it again.

# Interested parties
 @willtp87   @discoverygarden