### PR TITLE
multiple source query approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 This module provides a Drush script that can be used to bulk export datastreams
-given a Solr query.
+given a query to a source of PIDs.
 
 ## Requirements
 
@@ -25,20 +25,24 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 * [Islandora Dev Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora-dev)
 
 ## Usage
-Output of ```drush islandora_datastream_export --help:```
+Output of `drush islandora_datastream_export --help:`
 
 ```
 Exports a specified datastream from all objects given a fielded Solr query.
 
 Examples:
- drush -u 1 islandora_datastream_export  Exporting datastream from object.
- --export_target=/tmp --query=PID:\"islandora:9\" --dsid=DC
+ drush -u 1 islandora_datastream_export  Exporting datastream from object via default Solr query.
+ --export_target=/tmp
+ --query=PID:\"islandora:9\" --dsid=DC
 
 Options:
  --dsid                                    The datastream id of to be exported datastream. Required.
- --query                                   The Solr query to be ran. Required.
- --export_target                                  The directory to export the datastreams to. Required.
-  ```
+ --export_target                           The directory to export the datastreams to. Required.
+ --query                                   The query to be ran. Required.
+ --query_type                              The type of query to run. Check the output of "drush islandora_datastream_export_types" for a list. Defaults to "islandora_datastream_exporter_solr_query".
+```
+
+### Solr Backend
 
 It's to be noted that when specifying a value that some values will need to be
 escaped as the value is passed directly to Solr. An example of this is for the
@@ -48,6 +52,27 @@ of the query string must be provided as escaped. Boolean logic is allowed.
 
 Finally the user option (-u) needs to be specified or errors could be
 encountered when attempting to write the contents of the datastream to a file.
+
+### RI Backend
+
+To use the RI Backend:
+
+* Queries should be written in SPARQL format
+* Queries should `SELECT` a `?pid`
+* The contents of the query should be saved in a plaintext file, and provided
+  to the drush script as the `--query` parameter
+* To facilitate cycling through objects, the query should contain the string
+  `%offset%`, which will be replaced by the current offset of the batch. For
+  example:
+
+```
+SELECT ?pid
+FROM <#ri>
+WHERE {
+  ?pid <fedora-rels-ext:isMemberOfCollection> <info:fedora/some:collection>
+}
+OFFSET %offset%
+```
 
 ## Maintainers/Sponsors
 

--- a/includes/ri.query.inc
+++ b/includes/ri.query.inc
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Functionality for the RI query backend.
+ */
+
+/**
+ * Callback to validate the RI query.
+ */
+function islandora_datastream_exporter_ri_query_validate($query) {
+  if (!is_readable($query)) {
+    return drush_set_error('Cannot read file', dt('Could not read the file specified at !path', array('!path' => $query)));
+  }
+  $tuque = islandora_get_tuque_connection();
+  try {
+    $results = $tuque->repository->ri->sparqlQuery(_islandora_datastream_exporter_ri_query_offset_replace(file_get_contents($query), 0), 1);
+    if (empty($results)) {
+      return drush_set_error('No result RI query', dt('The specified query at the given location returned no results.'));
+    }
+  }
+  catch (RepositoryException $e) {
+    return drush_set_error('Invalid request', dt('An error occurred attempting to perform the query provided: !e', array('!e' => $e->getMessage())));
+  }
+}
+
+/**
+ * Callback to provide PIDs from the RI query.
+ */
+function islandora_datastream_exporter_ri_query_pid_source($query, $max, &$context) {
+  $tuque = islandora_get_tuque_connection();
+  $sandbox = &$context['sandbox'];
+  if (!isset($sandbox['offset'])) {
+    $sandbox['query'] = file_get_contents($query);
+    $sandbox['total'] = $tuque->repository->ri->countQuery(_islandora_datastream_exporter_ri_query_offset_replace($sandbox['query'], 0), 'sparql');
+    $sandbox['offset'] = 0;
+  }
+  $results = $tuque->repository->ri->sparqlQuery(_islandora_datastream_exporter_ri_query_offset_replace($sandbox['query'], $sandbox['offset']), $max);
+  $context['message'] = t('Processing results @start to @end', array(
+    '@start' => $sandbox['offset'] + 1,
+    '@end' => min($sandbox['offset'] + $max, $sandbox['total']),
+  ));
+  $sandbox['offset'] += count($results);
+  $get_pid = function ($result) {
+    return $result['pid']['value'];
+  };
+  $context['finished'] = $sandbox['offset'] / $sandbox['total'];
+  return array_map($get_pid, $results);
+}
+
+/**
+ * Helper to swap the %offset% for a proper query.
+ */
+function _islandora_datastream_exporter_ri_query_offset_replace($query, $offset) {
+  return str_replace('%offset%', $offset, $query);
+}

--- a/includes/solr.query.inc
+++ b/includes/solr.query.inc
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @file
+ * Functionality for the Solr query backend.
+ */
+
+/**
+ * Callback to validate the Solr query.
+ */
+function islandora_datastream_exporter_solr_query_validate($query) {
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildQuery($query);
+  $qp->solrLimit = 1;
+  $qp->executeQuery(FALSE);
+  if (empty($qp->islandoraSolrResult)) {
+    return drush_set_error('Invalid Solr query', dt('The specified query !query is not valid. Please ensure you have a correct and escaped query.', array('!query' => $query)));
+  }
+  elseif ($qp->islandoraSolrResult['response']['numFound'] === 0) {
+    return drush_set_error('No result Solr query', dt('The specified query !query returned no results.', array('!query' => $query)));
+  }
+}
+
+/**
+ * Callback to provide PIDs from the Solr query.
+ */
+function islandora_datastream_exporter_solr_query_pid_source($query, $max, &$context) {
+  $sandbox = &$context['sandbox'];
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildQuery($query);
+  if (!isset($sandbox['offset'])) {
+    $qp->executeQuery(FALSE);
+    $sandbox['total'] = $qp->islandoraSolrResult['response']['numFound'];
+    $sandbox['offset'] = 0;
+  }
+  $context['message'] = t('Processing results @start to @end.', array(
+    '@start' => $sandbox['offset'] + 1,
+    '@end' => min($sandbox['offset'] + $max, $sandbox['total']),
+  ));
+  $qp->solrLimit = $max;
+  $qp->solrStart = $sandbox['offset'];
+  $qp->executeQuery();
+  $results = $qp->islandoraSolrResult['response']['objects'];
+  $sandbox['offset'] += $max;
+  $get_pid = function ($doc) {
+    return $doc['PID'];
+  };
+  $context['finished'] = $sandbox['offset'] / $sandbox['total'];
+  return array_map($get_pid, $results);
+}

--- a/islandora_datastream_exporter.api.php
+++ b/islandora_datastream_exporter.api.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @file
+ * API functionality.
+ */
+
+/**
+ * Allows for sources of PID lists to be provided to the exporter.
+ *
+ * @return array
+ *   An associative array pairing PID list source names with definitions,
+ *   including:
+ *   - 'file': A file to load, using an array of parameters as one would pass to
+ *     module_load_include(). Not required.
+ *   - 'validation_callback': A function to call to validate the drush script's
+ *     query parameter. Not required.
+ *   - 'pid_source_callback': A function to call to get a list of PIDs.
+ *     Required.
+ *   - 'description': Some descriptive information for the query type. Not 
+ *     required.
+ */
+function hook_islandora_datastream_exporter_pid_source() {
+  return array(
+    'my_cool_exporter' => array(
+      'file' => array('inc', 'my_cool_exporter', 'includes/exporter'),
+      'validation_callback' => 'my_cool_exporter_validation_callback',
+      'pid_source_callback' => 'my_cool_exporter_pid_source_callback',
+      'description' => t('Some cool exporter'),
+    ),
+  );
+}
+
+/**
+ * Example validation callback.
+ *
+ * @param string $query
+ *   The drush script query parameter.
+ *
+ * @return bool
+ *   FALSE if we should not continue; TRUE otherwise. Prefer to return the
+ *   result of drush_set_error() if issues occur so that messaging is provided.
+ */
+function my_cool_exporter_validation_callback($query) {
+  if ($query !== 'totally valid query') {
+    return drush_set_error('Nope', 'This is not even valid what are you doing');
+  }
+  return TRUE;
+}
+
+/**
+ * Example PID source callback.
+ *
+ * @param string $query
+ *   The drush script's query parameter.
+ * @param int $max
+ *   The maximum number of PIDs to return.
+ * @param array|DrushBatchContext $context
+ *   The batch context, passed in by reference, so that messaging and sandboxing
+ *   can be provided. It is also expected that this callback will set the
+ *   'finished' parameter.
+ *
+ * @return string[]
+ *   An array containing PIDs as strings. If an empty array is returned, batch
+ *   execution will stop.
+ */
+function my_cool_exporter_pid_source_callback($query, $max, &$context) {
+  $sandbox =& $context['sandbox'];
+  if (empty($sandbox) {
+    $sandbox['offset'] = 0;
+  }
+  $pids = do_something_cool_with_query($query, $max, $sandbox['offset']);
+  $sandbox['offset'] += count($pids);
+  return $pids;
+}

--- a/islandora_datastream_exporter.drush.inc
+++ b/islandora_datastream_exporter.drush.inc
@@ -122,7 +122,7 @@ function islandora_datastream_export_batch_operation($type, $query, $dsid, $targ
     call_user_func_array('module_load_include', $type['file']);
   }
   module_load_include('inc', 'islandora', 'includes/mimetype.utils');
-  module_load_include('inc', 'islandora', 'utilities');
+  module_load_include('inc', 'islandora', 'includes/utilities');
   $results = call_user_func_array($type['pid_source_callback'], array(
     $query,
     $export_objects,

--- a/islandora_datastream_exporter.drush.inc
+++ b/islandora_datastream_exporter.drush.inc
@@ -14,11 +14,14 @@ function islandora_datastream_exporter_drush_command() {
     'description' => dt('Exports a specified datastream from all objects given a fielded Solr query.'),
     'drupal dependencies' => array(
       'islandora',
-      'islandora_solr',
     ),
     'options' => array(
+      'query_type' => array(
+        'description' => dt('The type of query to run. Check the output of "drush islandora_datastream_export_types" for a list. Defaults to "islandora_datastream_exporter_solr_query".'),
+        'required' => FALSE,
+      ),
       'query' => array(
-        'description' => dt('The Solr query to be ran.'),
+        'description' => dt('The query to be ran.'),
         'required' => TRUE,
       ),
       'dsid' => array(
@@ -31,8 +34,13 @@ function islandora_datastream_exporter_drush_command() {
       ),
     ),
     'examples' => array(
-      'drush -u 1 islandora_datastream_export --export_target=/tmp --query=PID:\"islandora:9\" --dsid=DC' => dt('Exporting datastream from object.'),
+      'drush -u 1 islandora_datastream_export --export_target=/tmp --query=PID:\"islandora:9\" --dsid=DC' => dt('Exporting datastream from object via default Solr query.'),
     ),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
+  );
+  $commands['islandora_datastream_export_types'] = array(
+    'description' => dt('Lists the types of exporters available.'),
+    'examples' => array('drush islandora_datastream_export_types'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
   return $commands;
@@ -42,21 +50,21 @@ function islandora_datastream_exporter_drush_command() {
  * Batch process validation handler.
  */
 function drush_islandora_datastream_exporter_islandora_datastream_export_validate() {
+  $types = module_invoke_all('islandora_datastream_exporter_pid_source');
+  $type = drush_get_option('query_type', 'islandora_datastream_exporter_solr_query');
+  if (!isset($types[$type])) {
+    return drush_set_error('Invalid type', dt('The specified type, !type, is not valid.', array('!type' => $type)));
+  }
   $directory = drush_get_option('export_target');
   if (!is_writable($directory)) {
     return drush_set_error('This is not is a directory', dt('The specified target directory, !dir, is not valid.', array('!dir' => $directory)));
   }
   $query = drush_get_option('query');
-  $qp = new IslandoraSolrQueryProcessor();
-  $qp->buildQuery($query);
-  $qp->solrLimit = 1;
-  $qp->executeQuery(FALSE);
-  if (empty($qp->islandoraSolrResult)) {
-    return drush_set_error('Invalid Solr query', dt('The specified query !query is not valid. Please ensure you have a correct and escaped query.', array('!query' => $query)));
-  }
-  elseif ($qp->islandoraSolrResult['response']['numFound'] === 0) {
-    return drush_set_error('No result Solr query', dt('The specified query !query returned no results.', array('!query' => $query)));
-
+  if (isset($types[$type]['validation_callback'])) {
+    if (isset($types[$type]['file'])) {
+      call_user_func_array('module_load_include', $types[$type]['file']);
+    }
+    return call_user_func_array($types[$type]['validation_callback'], array($query));
   }
 }
 
@@ -72,10 +80,13 @@ function drush_islandora_datastream_exporter_islandora_datastream_export() {
  * Constructs a batch used to update things via Drush.
  */
 function islandora_datastream_export_create_batch() {
+  $types = module_invoke_all('islandora_datastream_exporter_pid_source');
+  $type = drush_get_option('query_type', 'islandora_datastream_exporter_solr_query');
   return array(
     'operations' => array(
       array('islandora_datastream_export_batch_operation',
         array(
+          $types[$type],
           drush_get_option('query'),
           drush_get_option('dsid'),
           drush_get_option('export_target'),
@@ -93,6 +104,8 @@ function islandora_datastream_export_create_batch() {
 /**
  * Constructs and performs the datastream export operation.
  *
+ * @param array $type
+ *   A type definition array for the PID source.
  * @param string $query
  *   The Solr query to be used for searching.
  * @param string $dsid
@@ -102,28 +115,21 @@ function islandora_datastream_export_create_batch() {
  * @param array $context
  *   The context of the Drupal batch.
  */
-function islandora_datastream_export_batch_operation($query, $dsid, $target, &$context) {
-  $sandbox = &$context['sandbox'];
+function islandora_datastream_export_batch_operation($type, $query, $dsid, $target, &$context) {
+  drupal_static_reset('islandora_get_tuque_connection');
   $export_objects = 10;
-  $qp = new IslandoraSolrQueryProcessor();
-  $qp->buildQuery($query);
-  if (!isset($sandbox['offset'])) {
-    $qp->executeQuery(FALSE);
-    $sandbox['total'] = $qp->islandoraSolrResult['response']['numFound'];
-    $sandbox['offset'] = 0;
+  if (isset($type['file'])) {
+    call_user_func_array('module_load_include', $type['file']);
   }
-  $context['message'] = t('Processing results @start to @end.', array(
-    '@start' => $sandbox['offset'],
-    '@end' => min($sandbox['offset'] + $export_objects, $sandbox['total']),
+  module_load_include('inc', 'islandora', 'includes/mimetype.utils');
+  module_load_include('inc', 'islandora', 'utilities');
+  $results = call_user_func_array($type['pid_source_callback'], array(
+    $query,
+    $export_objects,
+    &$context,
   ));
-  $qp->solrLimit = $export_objects;
-  $qp->solrStart = $sandbox['offset'];
-  $qp->executeQuery();
-  $results = $qp->islandoraSolrResult['response']['objects'];
-  foreach ($results as $solr_doc) {
-    module_load_include('inc', 'islandora', 'includes/mimetype.utils');
-    module_load_include('inc', 'islandora', 'utilities');
-    $object = islandora_object_load($solr_doc['PID']);
+  foreach ($results as $pid) {
+    $object = islandora_object_load($pid);
     if (isset($object[$dsid])) {
       $extension = islandora_get_extension_for_mimetype($object[$dsid]->mimeType);
       $file_pid = islandora_escape_pid_for_function($object->id);
@@ -144,6 +150,18 @@ function islandora_datastream_export_batch_operation($query, $dsid, $target, &$c
       )), 'error');
     }
   }
-  $sandbox['offset'] += $export_objects;
-  $context['finished'] = $sandbox['offset'] / $sandbox['total'];
+}
+
+/**
+ * Lists the types of exporters.
+ */
+function drush_islandora_datastream_exporter_islandora_datastream_export_types() {
+  foreach (module_invoke_all('islandora_datastream_exporter_pid_source') as $type => $source) {
+    if (isset($source['description'])) {
+      drush_print("$type: {$source['description']}");
+    }
+    else {
+      drush_print($type);
+    }
+  }
 }

--- a/islandora_datastream_exporter.module
+++ b/islandora_datastream_exporter.module
@@ -3,3 +3,23 @@
  * @file
  * Module file for islandora_datastream_exporter.
  */
+
+/**
+ * Implements hook_islandora_datastream_exporter_pid_source().
+ */
+function islandora_datastream_exporter_islandora_datastream_exporter_pid_source() {
+  return array(
+    'islandora_datastream_exporter_solr_query' => array(
+      'file' => array('inc', 'islandora_datastream_exporter', 'includes/solr.query'),
+      'validation_callback' => 'islandora_datastream_exporter_solr_query_validate',
+      'pid_source_callback' => 'islandora_datastream_exporter_solr_query_pid_source',
+      'description' => t('Takes a query in the form of a string representing a Solr query.'),
+    ),
+    'islandora_datastream_exporter_ri_query' => array(
+      'file' => array('inc', 'islandora_datastream_exporter', 'includes/ri.query'),
+      'validation_callback' => 'islandora_datastream_exporter_ri_query_validate',
+      'pid_source_callback' => 'islandora_datastream_exporter_ri_query_pid_source',
+      'description' => t('Takes the path to a plain text file containing an RI query in SPARQL format. Query results should return a ?pid parameter, and contain the string "%offset%" representing the amount the results should be offset by on each pass.'),
+    ),
+  );
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2377

# What does this Pull Request do?

Adds the ability to provide multiple sources for the PID list to export datastreams, and adds an RI backend.

# What's new?

* A hook to provide multiple sources for the PID lists
* The Solr query has been made the default source, and given an implementation in the hook
* An RI query implementation has been added

# How should this be tested?

* Using `drush islandora_datastream_export` before and after pulling these commits should function precisely the same (almost ... the counts weren't displaying correctly and have been updated).
* Using the `drush islandora_datastream_export` command with `--query_type=islandora_datastream_exporter_ri_query` should function as documented now in the README.
* Using the `drush islandora_datastream_export_types` command should show all implementations of the `--query_type` parameter.

Note that after pulling code, `drush cc all` will be necessary, as hook implementations need to be updated.

# Interested parties
Maintainer: @willtp87 
